### PR TITLE
Fix a bug that BollingerBands returns wrong action

### DIFF
--- a/src/indicators/bollinger_bands.rs
+++ b/src/indicators/bollinger_bands.rs
@@ -130,10 +130,10 @@ impl IndicatorInstance for BollingerBandsInstance {
 		let values = [upper, middle, lower];
 
 		let range = upper - lower;
-		let relative = if range == 0.0 {
+		let relative = if range != 0.0 {
 			(source - lower) / range
 		} else {
-			0.0
+			0.5
 		};
 
 		let signals = [Action::from(relative * 2.0 - 1.0)];


### PR DESCRIPTION
I fixed range condition to calculate `relative` right.

And if range is zero, it would be your intention to produce Action::None. so relative would be 0.5, not zero