### PR TITLE
Add traits to core::Error for anyhow support

### DIFF
--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -19,3 +19,22 @@ pub enum Error {
 	/// Any other error
 	Other(String),
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SourceParse(value) => write!(f, "unable to parse value as Source: {:?}", value),
+            Self::ParameterParse(name, value) => write!(f, "unable to parse into {}: {:?}", name, value),
+            Self::WrongMethodParameters => write!(f, "wrong method parameters"),
+            Self::WrongConfig => write!(f, "wrong config"),
+            Self::InvalidCandles => write!(f, "invalid candles"),
+            Self::Other(reason) => write!(f, "{}", reason),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}


### PR DESCRIPTION
This allows use with `anyhow::Result<T>` as the traits let anyhow convert `yata::core::Error` into [anyhow::Error](https://docs.rs/anyhow/1.0.38/anyhow/struct.Error.html).