### PR TITLE
need send on some traits

### DIFF
--- a/src/core/indicator/config.rs
+++ b/src/core/indicator/config.rs
@@ -7,7 +7,7 @@ use crate::core::{Error, OHLCV};
 ///
 /// See example with [`Example Indicator`](crate::indicators::example)
 // Config cannot be Copy because it might consist ov Vec-s. F.e. if indicator using Conv method with custom weights.
-pub trait IndicatorConfig: Clone {
+pub trait IndicatorConfig: Clone + Send {
 	/// Type of **State**
 	type Instance: IndicatorInstance<Config = Self>;
 

--- a/src/core/indicator/dd.rs
+++ b/src/core/indicator/dd.rs
@@ -2,7 +2,7 @@ use super::{IndicatorConfig, IndicatorInstance, IndicatorResult};
 use crate::core::{Error, OHLCV};
 
 /// Dynamically dispatchable [`IndicatorConfig`](crate::core::IndicatorConfig)
-pub trait IndicatorConfigDyn<T: OHLCV> {
+pub trait IndicatorConfigDyn<T: OHLCV> : Send {
 	/// Dynamically initializes the **State** based on the current **Configuration**
 	fn init(&self, initial_value: &T) -> Result<Box<dyn IndicatorInstanceDyn<T>>, Error>;
 
@@ -37,7 +37,7 @@ impl<T, I, C> IndicatorConfigDyn<T> for C
 where
 	T: OHLCV,
 	I: IndicatorInstanceDyn<T> + IndicatorInstance<Config = Self> + 'static,
-	C: IndicatorConfig<Instance = I> + Clone + 'static,
+	C: IndicatorConfig<Instance = I> + Clone + Send + 'static,
 {
 	fn init(&self, initial_value: &T) -> Result<Box<dyn IndicatorInstanceDyn<T>>, Error> {
 		let instance = IndicatorConfig::init(self.clone(), initial_value)?;
@@ -66,7 +66,7 @@ where
 }
 
 /// Dynamically dispatchable [`IndicatorInstance`](crate::core::IndicatorInstance)
-pub trait IndicatorInstanceDyn<T: OHLCV> {
+pub trait IndicatorInstanceDyn<T: OHLCV> : Send {
 	/// Evaluates given candle and returns [`IndicatorResult`](crate::core::IndicatorResult)
 	fn next(&mut self, candle: &T) -> IndicatorResult;
 
@@ -101,7 +101,7 @@ pub trait IndicatorInstanceDyn<T: OHLCV> {
 impl<T, I> IndicatorInstanceDyn<T> for I
 where
 	T: OHLCV,
-	I: IndicatorInstance + 'static,
+	I: IndicatorInstance + Send + 'static,
 {
 	fn next(&mut self, candle: &T) -> IndicatorResult {
 		IndicatorInstance::next(self, candle)

--- a/src/core/moving_average.rs
+++ b/src/core/moving_average.rs
@@ -20,7 +20,7 @@ pub trait MovingAverage: Method<Input = ValueType, Output = ValueType> {}
 /// This trait plays the same role for moving averages as [`IndicatorConfig`] plays for indicators.
 ///
 /// [`IndicatorConfig`]: crate::core::IndicatorConfig
-pub trait MovingAverageConstructor: Clone + FromStr {
+pub trait MovingAverageConstructor: Send + Clone + FromStr {
 	/// Used for comparing MA types
 	type Type: Eq;
 


### PR DESCRIPTION
Hi, I'm using yata with pyo3 which requires boxed values to be Send.
IndicatorInstance isn't Send so I can't send IndicatorInstanceDyn between threads unless I mark it with Send, since IndicatorConfigDyn::init returns IndicatorInstanceDyn which isn't Send, I figured I needed to add the trait explicitly.

If you have a better option or recommendation feel free to close the PR with comment.