### PR TITLE
Enable indicators' instances to be reused

### DIFF
--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -50,109 +50,109 @@ impl OHLCV for HLC {
 }
 
 mod aroon;
-pub use aroon::Aroon;
+pub use aroon::{Aroon, AroonInstance};
 
 mod average_directional_index;
-pub use average_directional_index::AverageDirectionalIndex;
+pub use average_directional_index::{AverageDirectionalIndex, AverageDirectionalIndexInstance};
 
 mod awesome_oscillator;
-pub use awesome_oscillator::AwesomeOscillator;
+pub use awesome_oscillator::{AwesomeOscillator, AwesomeOscillatorInstance};
 
 mod bollinger_bands;
-pub use bollinger_bands::BollingerBands;
+pub use bollinger_bands::{BollingerBands, BollingerBandsInstance};
 
 mod chaikin_money_flow;
-pub use chaikin_money_flow::ChaikinMoneyFlow;
+pub use chaikin_money_flow::{ChaikinMoneyFlow, ChaikinMoneyFlowInstance};
 
 mod chaikin_oscillator;
-pub use chaikin_oscillator::ChaikinOscillator;
+pub use chaikin_oscillator::{ChaikinOscillator, ChaikinOscillatorInstance};
 
 mod chande_kroll_stop;
-pub use chande_kroll_stop::ChandeKrollStop;
+pub use chande_kroll_stop::{ChandeKrollStop, ChandeKrollStopInstance};
 
 mod chande_momentum_oscillator;
-pub use chande_momentum_oscillator::ChandeMomentumOscillator;
+pub use chande_momentum_oscillator::{ChandeMomentumOscillator, ChandeMomentumOscillatorInstance};
 
 mod commodity_channel_index;
-pub use commodity_channel_index::CommodityChannelIndex;
+pub use commodity_channel_index::{CommodityChannelIndex, CommodityChannelIndexInstance};
 
 mod coppock_curve;
-pub use coppock_curve::CoppockCurve;
+pub use coppock_curve::{CoppockCurve, CoppockCurveInstance};
 
 mod detrended_price_oscillator;
-pub use detrended_price_oscillator::DetrendedPriceOscillator;
+pub use detrended_price_oscillator::{DetrendedPriceOscillator, DetrendedPriceOscillatorInstance};
 
 mod donchian_channel;
-pub use donchian_channel::DonchianChannel;
+pub use donchian_channel::{DonchianChannel, DonchianChannelInstance};
 
 mod ease_of_movement;
-pub use ease_of_movement::EaseOfMovement;
+pub use ease_of_movement::{EaseOfMovement, EaseOfMovementInstance};
 
 mod elders_force_index;
-pub use elders_force_index::EldersForceIndex;
+pub use elders_force_index::{EldersForceIndex, EldersForceIndexInstance};
 
 mod envelopes;
-pub use envelopes::Envelopes;
+pub use envelopes::{Envelopes, EnvelopesInstance};
 
 mod fisher_transform;
-pub use fisher_transform::FisherTransform;
+pub use fisher_transform::{FisherTransform, FisherTransformInstance};
 
 mod hull_moving_average;
-pub use hull_moving_average::HullMovingAverage;
+pub use hull_moving_average::{HullMovingAverage, HullMovingAverageInstance};
 
 mod ichimoku_cloud;
-pub use ichimoku_cloud::IchimokuCloud;
+pub use ichimoku_cloud::{IchimokuCloud, IchimokuCloudInstance};
 
 mod kaufman;
-pub use kaufman::{Kaufman, KAMA};
+pub use kaufman::{Kaufman, KaufmanInstance, KAMA};
 
 mod keltner_channel;
-pub use keltner_channel::KeltnerChannel;
+pub use keltner_channel::{KeltnerChannel, KeltnerChannelInstance};
 
 mod klinger_volume_oscillator;
-pub use klinger_volume_oscillator::KlingerVolumeOscillator;
+pub use klinger_volume_oscillator::{KlingerVolumeOscillator, KlingerVolumeOscillatorInstance};
 
 mod know_sure_thing;
-pub use know_sure_thing::KnowSureThing;
+pub use know_sure_thing::{KnowSureThing, KnowSureThingInstance};
 
 mod macd;
-pub use macd::{MovingAverageConvergenceDivergence, MACD};
+pub use macd::{MovingAverageConvergenceDivergence, MACD, MACDInstance};
 
 mod momentum_index;
-pub use momentum_index::MomentumIndex;
+pub use momentum_index::{MomentumIndex, MomentumIndexInstance};
 
 mod money_flow_index;
-pub use money_flow_index::MoneyFlowIndex;
+pub use money_flow_index::{MoneyFlowIndex, MoneyFlowIndexInstance};
 
 mod parabolic_sar;
-pub use parabolic_sar::{ParabolicSAR, ParabolicStopAndReverse};
+pub use parabolic_sar::{ParabolicSAR, ParabolicSARInstance, ParabolicStopAndReverse};
 
 mod pivot_reversal_strategy;
-pub use pivot_reversal_strategy::PivotReversalStrategy;
+pub use pivot_reversal_strategy::{PivotReversalStrategy, PivotReversalStrategyInstance};
 
 mod price_channel_strategy;
-pub use price_channel_strategy::PriceChannelStrategy;
+pub use price_channel_strategy::{PriceChannelStrategy, PriceChannelStrategyInstance};
 
 mod relative_strength_index;
-pub use relative_strength_index::{RelativeStrengthIndex, RSI};
+pub use relative_strength_index::{RelativeStrengthIndex, RelativeStrengthIndexInstance, RSI};
 
 mod relative_vigor_index;
-pub use relative_vigor_index::RelativeVigorIndex;
+pub use relative_vigor_index::{RelativeVigorIndex, RelativeVigorIndexInstance};
 
 mod smi_ergodic_indicator;
-pub use smi_ergodic_indicator::SMIErgodicIndicator;
+pub use smi_ergodic_indicator::{SMIErgodicIndicator, SMIErgodicIndicatorInstance};
 
 mod stochastic_oscillator;
-pub use stochastic_oscillator::StochasticOscillator;
+pub use stochastic_oscillator::{StochasticOscillator, StochasticOscillatorInstance};
 
 mod trix;
-pub use trix::Trix;
+pub use trix::{Trix, TrixInstance};
 
 mod trend_strength_index;
-pub use trend_strength_index::TrendStrengthIndex;
+pub use trend_strength_index::{TrendStrengthIndex, TrendStrengthIndexInstance};
 
 mod true_strength_index;
-pub use true_strength_index::TrueStrengthIndex;
+pub use true_strength_index::{TrueStrengthIndex, TrueStrengthIndexInstance};
 
 mod woodies_cci;
-pub use woodies_cci::WoodiesCCI;
+pub use woodies_cci::{WoodiesCCI, WoodiesCCIInstance};

--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -146,7 +146,7 @@ mod stochastic_oscillator;
 pub use stochastic_oscillator::{StochasticOscillator, StochasticOscillatorInstance};
 
 mod trix;
-pub use trix::{Trix, TrixInstance};
+pub use trix::{Trix, TRIXInstance};
 
 mod trend_strength_index;
 pub use trend_strength_index::{TrendStrengthIndex, TrendStrengthIndexInstance};


### PR DESCRIPTION
Allows structs to be created with fields of instances types to store them for reuse.