### PR TITLE
feat: add rkyv derive for Candle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,12 @@ include = [
 ]
 
 [dependencies]
+rkyv = { version = "0.7.44", features = ["validation"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [features]
 default = ["serde"]
+rkyv = ["dep:rkyv"]
 period_type_u16 = []
 period_type_u32 = []
 period_type_u64 = []

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ By default, there is no `unsafe` code in the crate. But you can optionally enabl
 # Features
 
 - `serde` - enables [`serde`](https://crates.io/crates/serde) crate support;
+- `rkyv` - enables [`rkyv`](https://crates.io/crates/rkyv) derive on Candle;
 - `period_type_u16` - sets `PeriodType` to `u16`;
 - `period_type_u32` - sets `PeriodType` to `u32`;
 - `period_type_u64` - sets `PeriodType` to `u64`;

--- a/src/core/candles.rs
+++ b/src/core/candles.rs
@@ -117,6 +117,11 @@ impl From<Source> for String {
 /// ```
 #[derive(Debug, Clone, Copy, Default, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+	feature = "rkyv",
+	derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "rkyv", archive(check_bytes))]
 pub struct Candle {
 	/// *Open* value of the candle
 	pub open: ValueType,

--- a/src/indicators/donchian_channel.rs
+++ b/src/indicators/donchian_channel.rs
@@ -15,7 +15,7 @@ use crate::methods::{Highest, Lowest};
 ///
 /// * Lower bound
 ///
-/// Range is the same as [`high`] values.
+/// Range is the same as [`low`] values.
 ///
 /// * Middle value
 ///
@@ -25,7 +25,7 @@ use crate::methods::{Highest, Lowest};
 ///
 /// * Upper bound
 ///
-/// Range is the same as [`low`] values.
+/// Range is the same as [`high`] values.
 ///
 /// # 1 signal
 ///


### PR DESCRIPTION
Added rkyv derive for Candle behind feature gate, allowing the struct to be serialized / deserialized / stored using [rkyv](https://crates.io/crates/rkyv). 

Using rkyv significantly improved candles load performance for files, which is useful when doing backtesting. I am able to load 232k candles in 2 seconds using rkyv, compared to 28 seconds with serde-json. 

Also, minor fix on donchian_channel documentation. 